### PR TITLE
change div class based on gmaps in april 2023

### DIFF
--- a/googlemaps.py
+++ b/googlemaps.py
@@ -139,7 +139,7 @@ class GoogleMapsScraper:
         # parse reviews
         response = BeautifulSoup(self.driver.page_source, 'html.parser')
         # TODO: Subject to changes
-        rblock = response.find_all('div', class_='jftiEf fontBodyMedium')
+        rblock = response.find_all('div', class_='jftiEf fontBodyMedium ')
         parsed_reviews = []
         for index, review in enumerate(rblock):
             if index >= offset:


### PR DESCRIPTION
I needed this fix when I ran on the latest [master](https://github.com/gaspa93/googlemaps-scraper/commit/d19896679e73fb21d5ea7c3be2f20f66e43d3a99).

It was changed from 'jftiEf fontBodyMedium' to 'jftiEf fontBodyMedium ' (with one space　HaHa!).

![sc](https://user-images.githubusercontent.com/11247895/230924651-c72e7bbf-4bc3-4fe1-b636-f9cd9a65c28e.png)
