### PR TITLE
Aggiunta la possibilita' di passare il file output come parametro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,4 @@ test/
 !requirements.txt
 !urls.txt
 !urls_places.txt
+chromedriver*

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Follow these steps to use the scraper:
 ## Basic Usage
 The scraper.py script needs two main parameters as input:
 - `--i`: input file name, containing a list of urls that point to Google Maps place reviews (default: _urls.txt_)
+- `--o`: output file name, which will be created in the `data` folder (default: output.csv)
 - `--N`: number of reviews to retrieve, starting from the most recent (default: 100)
 
 Example:
@@ -22,8 +23,6 @@ Example:
   `python scraper.py --N 50`
 
 generates a csv file containing last 50 reviews of places present in _urls.txt_
-
-In current implementation, the CSV file is handled as an external function, so if you want to change path and/or name of output file, you need to modify that function.
 
 Additionally, other parameters can be provided:
 - `--place`: boolean value that allows to scrape POI metadata instead of reviews (default: false)

--- a/scraper.py
+++ b/scraper.py
@@ -11,9 +11,8 @@ ind = {'most_relevant' : 0 , 'newest' : 1, 'highest_rating' : 2, 'lowest_rating'
 HEADER = ['id_review', 'caption', 'relative_date', 'retrieval_date', 'rating', 'username', 'n_review_user', 'n_photo_user', 'url_user']
 HEADER_W_SOURCE = ['id_review', 'caption', 'relative_date','retrieval_date', 'rating', 'username', 'n_review_user', 'n_photo_user', 'url_user', 'url_source']
 
-def csv_writer(source_field, ind_sort_by, path='data/'):
-    outfile= ind_sort_by + '_gm_reviews.csv'
-    targetfile = open(path + outfile, mode='w', encoding='utf-8', newline='\n')
+def csv_writer(source_field, ind_sort_by, outpath):
+    targetfile = open('data/' + outpath, mode='w', encoding='utf-8', newline='\n')
     writer = csv.writer(targetfile, quoting=csv.QUOTE_MINIMAL)
 
     if source_field:
@@ -29,6 +28,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Google Maps reviews scraper.')
     parser.add_argument('--N', type=int, default=100, help='Number of reviews to scrape')
     parser.add_argument('--i', type=str, default='urls.txt', help='target URLs file')
+    parser.add_argument('--o', type=str, default='output.csv', help='output directory')
     parser.add_argument('--sort_by', type=str, default='newest', help='most_relevant, newest, highest_rating or lowest_rating')
     parser.add_argument('--place', dest='place', action='store_true', help='Scrape place metadata')
     parser.add_argument('--debug', dest='debug', action='store_true', help='Run scraper using browser graphical interface')
@@ -38,7 +38,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     # store reviews in CSV file
-    writer = csv_writer(args.source, args.sort_by)
+    writer = csv_writer(args.source, args.sort_by, args.o)
 
     with GoogleMapsScraper(debug=args.debug) as scraper:
         with open(args.i, 'r') as urls_file:


### PR DESCRIPTION
La modifica permette di specificare il file di output tramite il parametro --o. Questo rende lo script più flessibile e utilizzabile in pipelines dove serve salvare i risultati in posizioni specifiche.

Modifiche principali:
- Aggiunto il parametro --o per specificare il path del file di output
- Modificata la funzione csv_writer per utilizzare il path specificato
- Mantenuta la retrocompatibilità con il comportamento precedente (default: output.csv)